### PR TITLE
Update multi_add modules for v14

### DIFF
--- a/app_account_invoice_product_multi_add/i18n/fr.po
+++ b/app_account_invoice_product_multi_add/i18n/fr.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* app_account_invoice_product_multi_add
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-14 16:06+0000\n"
+"PO-Revision-Date: 2021-07-05 16:06+0000\n"
+"Last-Translator: remi-filament\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: app_account_invoice_product_multi_add
+#: model_terms:ir.ui.view,arch_db:app_account_invoice_product_multi_add.app_invoice_form
+#: model_terms:ir.ui.view,arch_db:app_account_invoice_product_multi_add.app_invoice_supplier_form
+msgid "Multi Add Line"
+msgstr "Ajouter plusieurs lignes"

--- a/app_account_invoice_product_multi_add/views/account_move_views.xml
+++ b/app_account_invoice_product_multi_add/views/account_move_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_move_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//page/field[@name='invoice_line_ids']/tree/control" position="inside">
-                    <create name="multi_add_line" string="Multi Add Line" context="{
+                    <create string="Multi Add Line" context="{
                     'pro_multi_add': True,
                     'pro_res_model': 'product.product',
                     'pro_res_field': 'product_id',

--- a/app_mrp_bom_product_multi_add/i18n/fr.po
+++ b/app_mrp_bom_product_multi_add/i18n/fr.po
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* app_mrp_bom_product_multi_add
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-14 16:07+0000\n"
+"PO-Revision-Date: 2021-07-05 16:07+0000\n"
+"Last-Translator: remi-filament\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: app_mrp_bom_product_multi_add
+#: model_terms:ir.ui.view,arch_db:app_mrp_bom_product_multi_add.app_mrp_bom_form_view
+msgid "Add a line"
+msgstr "Ajouter une ligne"
+
+#. module: app_mrp_bom_product_multi_add
+#: model_terms:ir.ui.view,arch_db:app_mrp_bom_product_multi_add.app_mrp_bom_form_view
+msgid "Multi add line"
+msgstr "Ajouter plusieurs lignes"

--- a/app_mrp_bom_product_multi_add/views/mrp_bom_views.xml
+++ b/app_mrp_bom_product_multi_add/views/mrp_bom_views.xml
@@ -7,8 +7,8 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='bom_line_ids']/tree/field[1]" position="before">
                     <control>
-                        <create name="add_line" string="Add a line"/>
-                        <create name="multi_add_line" string="Multi add line" context="{
+                        <create string="Add a line"/>
+                        <create string="Multi add line" context="{
                         'pro_multi_add': True,
                         'pro_res_model': 'product.product',
                         'pro_res_field': 'product_id',

--- a/app_purchase_product_multi_add/i18n/fr.po
+++ b/app_purchase_product_multi_add/i18n/fr.po
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* app_purchase_product_multi_add
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-14 15:59+0000\n"
+"PO-Revision-Date: 2021-07-05 15:59+0000\n"
+"Last-Translator: remi-filament\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: app_purchase_product_multi_add
+#: model_terms:ir.ui.view,arch_db:app_purchase_product_multi_add.app_purchase_order_form
+msgid "Add a product"
+msgstr "Ajouter une ligne"
+
+#. module: app_purchase_product_multi_add
+#: model_terms:ir.ui.view,arch_db:app_purchase_product_multi_add.app_purchase_order_form
+msgid "Multi Add Product"
+msgstr "Ajouter plusieurs lignes"

--- a/app_purchase_product_multi_add/views/purchase_order_views.xml
+++ b/app_purchase_product_multi_add/views/purchase_order_views.xml
@@ -6,7 +6,7 @@
             <field name="inherit_id" ref="purchase.purchase_order_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//page/field[@name='order_line']/tree/control" position="inside">
-                    <create name="multi_add_line" string="Multi Add Product" context="{
+                    <create string="Multi Add Product" context="{
                     'pro_multi_add': True,
                     'pro_res_model': 'product.product',
                     'pro_res_field': 'product_id',

--- a/app_sale_product_multi_add/i18n/fr.po
+++ b/app_sale_product_multi_add/i18n/fr.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* app_sale_product_multi_add
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-22 10:38+0000\n"
+"PO-Revision-Date: 2021-07-05 10:38+0000\n"
+"Last-Translator: remi-filament\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: app_sale_product_multi_add
+#: model_terms:ir.ui.view,arch_db:app_sale_product_multi_add.app_view_order_form
+msgid "Multi add product"
+msgstr "Ajouter plusieurs produits"

--- a/app_sale_product_multi_add/views/sale_order_views.xml
+++ b/app_sale_product_multi_add/views/sale_order_views.xml
@@ -8,7 +8,7 @@
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//page/field[@name='order_line']/tree/control" position="inside">
-                    <create name="multi_add_line" string="Multi add product" context="{
+                    <create string="Multi add product" context="{
                         'pro_multi_add': True,
                         'pro_res_model': 'product.product',
                         'pro_res_field': 'product_id',

--- a/app_stock_picking_product_multi_add/i18n/fr.po
+++ b/app_stock_picking_product_multi_add/i18n/fr.po
@@ -4,11 +4,11 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0+e-20190301\n"
+"Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-03-14 16:03+0000\n"
-"PO-Revision-Date: 2021-07-05 16:03+0000\n"
-"Last-Translator: <>\n"
+"PO-Revision-Date: 2021-07-05 17:03+0000\n"
+"Last-Translator: remi-filament\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,10 +19,10 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:app_stock_picking_product_multi_add.app_view_picking_form
 #: model_terms:ir.ui.view,arch_db:app_stock_picking_product_multi_add.view_stock_move_line_detailed_operation_tree_multiline_add
 msgid "Add a line"
-msgstr "添加明细行"
+msgstr "Ajouter une ligne"
 
 #. module: app_stock_picking_product_multi_add
 #: model_terms:ir.ui.view,arch_db:app_stock_picking_product_multi_add.app_view_picking_form
 #: model_terms:ir.ui.view,arch_db:app_stock_picking_product_multi_add.view_stock_move_line_detailed_operation_tree_multiline_add
 msgid "Multi add line"
-msgstr "批量添加"
+msgstr "Ajouter plusieurs lignes"

--- a/app_stock_picking_product_multi_add/views/stock_picking_views.xml
+++ b/app_stock_picking_product_multi_add/views/stock_picking_views.xml
@@ -1,5 +1,22 @@
 <odoo>
     <data>
+        <record id="view_stock_move_line_detailed_operation_tree_multiline_add" model="ir.ui.view">
+            <field name="name">app.stock.move.line.multiline.add</field>
+            <field name="model">stock.move.line</field>
+            <field name="inherit_id" ref="stock.view_stock_move_line_detailed_operation_tree"/>
+            <field name="arch" type="xml">
+                <xpath expr="//tree/field[1]" position="before">
+                    <control>
+                        <create string="Add a line" context="{}"/>
+                        <create string="Multi add line" context="{
+                        'pro_multi_add': True,
+                        'pro_res_model': 'product.product',
+                        'pro_res_field': 'product_id',
+                        }"/>
+                    </control>
+                </xpath>
+            </field>
+        </record>
         <record id="app_view_picking_form" model="ir.ui.view">
             <field name="name">app.stock.picking.form</field>
             <field name="model">stock.picking</field>

--- a/app_stock_picking_product_multi_add/views/stock_picking_views.xml
+++ b/app_stock_picking_product_multi_add/views/stock_picking_views.xml
@@ -7,8 +7,8 @@
             <field name="arch" type="xml">
                 <xpath expr="//page/field[@name='move_ids_without_package']/tree/field[1]" position="before">
                     <control>
-                        <create name="add_line" string="Add a line"/>
-                        <create name="multi_add_line" string="Multi add line" context="{
+                        <create string="Add a line" context="{}"/>
+                        <create string="Multi add line" context="{
                         'pro_multi_add': True,
                         'pro_res_model': 'product.product',
                         'pro_res_field': 'product_id',


### PR DESCRIPTION
Dear @guohuadeng 
Thank you for your modules.
I have made a few changes on multi add modules, that I bring back to you with this PR :

- Add French translations
- Remove name="" from create since these are not authorized by schema (see https://github.com/odoo/odoo/blob/b9c561b4a9603b7ab912339a75f58c7c84df9c3f/odoo/addons/base/rng/common.rng#L413)
- Add multi-add function on detailed operations on stock picking

Let me know if you prefer that I split these commits in 3 PR ?
Best Regards,
Rémi